### PR TITLE
feat: allow installing deps through git

### DIFF
--- a/KoLmafia/dependencies.txt
+++ b/KoLmafia/dependencies.txt
@@ -1,1 +1,1 @@
-https://github.com/Ezandora/Choice-Override/branches/Release/
+github Ezandora/Choice-Override Release

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,1 +1,1 @@
-https://github.com/Ezandora/Choice-Override/branches/Release/
+github Ezandora/Choice-Override Release


### PR DESCRIPTION
In 2024, GitHub will deprecate SVN access. Allow installing the dependencies through git.